### PR TITLE
Add missing KeyCode::Back (Android back button)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -705,6 +705,7 @@ fn miniquad_key_to_yakui(key: KeyCode) -> Option<YakuiKeyCode> {
         KeyCode::RightAlt => Some(YakuiKeyCode::AltRight),
         KeyCode::RightSuper => Some(YakuiKeyCode::Super), // #FIXME: is this left super or right super? are they the same?
         KeyCode::Menu => Some(YakuiKeyCode::ContextMenu),
+        KeyCode::Back => Some(YakuiKeyCode::Escape),
         KeyCode::Unknown => None,
     }
 }


### PR DESCRIPTION
This PR fixes a compilation bug when using latest version of macroquand, yakui and this crate. I believe binding the Android back button to escape makes sense, but I am not totally sure.